### PR TITLE
Update minotourapi.py

### DIFF
--- a/minFQ/minotourapi.py
+++ b/minFQ/minotourapi.py
@@ -15,7 +15,7 @@ from minFQ.endpoints import EndPoint
 retry_strategy = Retry(
     total=6,
     status_forcelist=[429, 502, 503, 504],
-    method_whitelist=["HEAD", "GET", "OPTIONS", "POST"],
+    allowed_methods=["HEAD", "GET", "OPTIONS", "POST"],
     backoff_factor=1
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
Replacing deprecated 'method_whitelist' with 'allowed_methods' to fix bug with urllib3 v2.1.0 compatibility.